### PR TITLE
Fix setReelInDelay being setRecastDelay

### DIFF
--- a/src/main/java/ml/northwestwind/forgeautofish/config/gui/ReelInDelayScreen.java
+++ b/src/main/java/ml/northwestwind/forgeautofish/config/gui/ReelInDelayScreen.java
@@ -38,7 +38,7 @@ public class ReelInDelayScreen extends Screen {
                 long delay = Long.parseLong(reelInDelay.getText());
                 if (delay < Config.REEL_IN_DELAY_RANGE[1] || delay > Config.REEL_IN_DELAY_RANGE[2]) reelInDelay.setText(Long.toString(AutoFishHandler.reelInDelay));
                 else {
-                    Config.setRecastDelay(delay);
+                    Config.setReelInDelay(delay);
                     Minecraft.getInstance().displayGuiScreen(parent);
                 }
             }


### PR DESCRIPTION
Currently when using the reel in config it will save it as the recast delay, this fixes it.